### PR TITLE
Replace deprecated setID with setCode

### DIFF
--- a/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
+++ b/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
@@ -32,7 +32,7 @@ class InvoiceMapper
         );
 
         $customerTags = array(
-            'customer' => 'setID'
+            'customer' => 'setCode'
         );
 
         $totalsTags = array(


### PR DESCRIPTION
Fix for failing `InvoiceTest::testInvoiceMapperRespondsWithInvoiceEntity`
Using `setID` makes the tests fails because it is deprecated, with message:

```
"setID is a deprecated function: Use setCode".
```

Using `setCode` seems the better option
