### PR TITLE
Removed var_export() from Customer and Article

### DIFF
--- a/src/Pronamic/Twinfield/Article/Article.php
+++ b/src/Pronamic/Twinfield/Article/Article.php
@@ -140,7 +140,7 @@ class Article
 
     public function setAllowChangeVatCode($allowChangeVatCode)
     {
-        $this->allowChangeVatCode = var_export($allowChangeVatCode, true);
+        $this->allowChangeVatCode = $allowChangeVatCode;
         return $this;
     }
 
@@ -163,7 +163,7 @@ class Article
     public function setAllowChangePerformanceType($allowChangePerformanceType)
     {
         $this->allowChangePerformanceType
-            = var_export($allowChangePerformanceType, true);
+            = $allowChangePerformanceType;
         return $this;
     }
 
@@ -185,7 +185,7 @@ class Article
 
     public function setAllowDiscountorPremium($allowDiscountorPremium)
     {
-        $this->allowDiscountorPremium = var_export($allowDiscountorPremium, true);
+        $this->allowDiscountorPremium = $allowDiscountorPremium;
         return $this;
     }
 
@@ -196,7 +196,7 @@ class Article
 
     public function setAllowChangeUnitsPrice($allowChangeUnitsPrice)
     {
-        $this->allowChangeUnitsPrice = var_export($allowChangeUnitsPrice, true);
+        $this->allowChangeUnitsPrice = $allowChangeUnitsPrice;
         return $this;
     }
 
@@ -207,7 +207,7 @@ class Article
 
     public function setAllowDecimalQuantity($allowDecimalQuantity)
     {
-        $this->allowDecimalQuantity = var_export($allowDecimalQuantity, true);
+        $this->allowDecimalQuantity = $allowDecimalQuantity;
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -241,7 +241,7 @@ class Customer
 
     public function setPayAvailable($payAvailable)
     {
-        $this->payAvailable = var_export($payAvailable, true);
+        $this->payAvailable = $payAvailable;
         return $this;
     }
 
@@ -274,7 +274,7 @@ class Customer
 
     public function setEBilling($eBilling)
     {
-        $this->eBilling = var_export($eBilling, true);
+        $this->eBilling = $eBilling;
         return $this;
     }
 


### PR DESCRIPTION
The use var_export() made that Boolean values returned for Twinfield where stored as a string with qoutes like so " ' true ' " (spaces are there to highlight the issue) in the two classes edited here.

Sub-classes didn't use var_export for Boolean values so the issue didn't exist there.

Could you activate the  Service Hook in Twinfield so the packages on Packagist are updated again?