### PR TITLE
Added remove{Type} methods for all sub-objects inserted into an array in the main object

### DIFF
--- a/src/Pronamic/Twinfield/Article/Article.php
+++ b/src/Pronamic/Twinfield/Article/Article.php
@@ -224,7 +224,11 @@ class Article
 
     public function removeLine($index)
     {
-        unset($this->lines[$index]);
-        return $this;
+        if(array_key_exists($index, $this->lines)){
+            unset($this->lines[$index]);
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/Pronamic/Twinfield/Article/Article.php
+++ b/src/Pronamic/Twinfield/Article/Article.php
@@ -221,4 +221,10 @@ class Article
         $this->lines[] = $line;
         return $this;
     }
+
+    public function removeLine($index)
+    {
+        unset($this->lines[$index]);
+        return $this;
+    }
 }

--- a/src/Pronamic/Twinfield/Article/Article.php
+++ b/src/Pronamic/Twinfield/Article/Article.php
@@ -218,7 +218,7 @@ class Article
 
     public function addLine(ArticleLine $line)
     {
-        $this->lines[] = $line;
+        $this->lines[$line->getID()] = $line;
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Article/ArticleLine.php
+++ b/src/Pronamic/Twinfield/Article/ArticleLine.php
@@ -4,7 +4,7 @@ namespace Pronamic\Twinfield\Article;
 
 class ArticleLine
 {
-    private $ID;
+    private $ID = uniqid();
     private $status;
     private $inUse;
     private $unitsPriceExcl;
@@ -14,6 +14,11 @@ class ArticleLine
     private $shortName;
     private $subCode;
     private $freeText1;
+
+    public __construct()
+    {
+        $this->ID = uniqid();
+    }
 
     public function getID()
     {

--- a/src/Pronamic/Twinfield/Article/ArticleLine.php
+++ b/src/Pronamic/Twinfield/Article/ArticleLine.php
@@ -4,7 +4,7 @@ namespace Pronamic\Twinfield\Article;
 
 class ArticleLine
 {
-    private $ID = uniqid();
+    private $ID;
     private $status;
     private $inUse;
     private $unitsPriceExcl;

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -332,7 +332,7 @@ class Customer
 
     public function addBank(CustomerBank $bank)
     {
-        $this->banks[$bank->getID] = $bank;
+        $this->banks[$bank->getID()] = $bank;
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -315,6 +315,12 @@ class Customer
         return $this;
     }
 
+    public function deleteAddress($index)
+    {
+        unset($this->banks[$index]);
+        return $this;
+    }
+
     public function getBanks()
     {
         return $this->banks;
@@ -323,6 +329,12 @@ class Customer
     public function addBank(CustomerBank $bank)
     {
         $this->banks[] = $bank;
+        return $this;
+    }
+
+    public function deleteBank($index)
+    {
+        unset($this->banks[$index]);
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -315,9 +315,9 @@ class Customer
         return $this;
     }
 
-    public function deleteAddress($index)
+    public function removeAddress($index)
     {
-        unset($this->banks[$index]);
+        unset($this->adressess[$index]);
         return $this;
     }
 
@@ -332,7 +332,7 @@ class Customer
         return $this;
     }
 
-    public function deleteBank($index)
+    public function removeBank($index)
     {
         unset($this->banks[$index]);
         return $this;

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -332,7 +332,7 @@ class Customer
 
     public function addBank(CustomerBank $bank)
     {
-        $this->banks[] = $bank;
+        $this->banks[$bank->getID] = $bank;
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -311,7 +311,7 @@ class Customer
 
     public function addAddress(CustomerAddress $address)
     {
-        $this->addresses[] = $address;
+        $this->addresses[$address->getID()] = $address;
         return $this;
     }
 

--- a/src/Pronamic/Twinfield/Customer/Customer.php
+++ b/src/Pronamic/Twinfield/Customer/Customer.php
@@ -317,8 +317,12 @@ class Customer
 
     public function removeAddress($index)
     {
-        unset($this->adressess[$index]);
-        return $this;
+        if (array_key_exists($index, $this->addressess)) {
+            unset($this->adressess[$index]);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function getBanks()
@@ -334,8 +338,12 @@ class Customer
 
     public function removeBank($index)
     {
-        unset($this->banks[$index]);
-        return $this;
+        if (array_key_exists($index, $this->banks)) {
+            unset($this->banks[$index]);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function getGroups()

--- a/src/Pronamic/Twinfield/Customer/CustomerAddress.php
+++ b/src/Pronamic/Twinfield/Customer/CustomerAddress.php
@@ -22,6 +22,11 @@ class CustomerAddress
     private $field5;
     private $field6;
 
+    public function __construct()
+    {
+        $this->ID = uniqid();
+    }
+
     public function getID()
     {
         return $this->ID;

--- a/src/Pronamic/Twinfield/Customer/CustomerBank.php
+++ b/src/Pronamic/Twinfield/Customer/CustomerBank.php
@@ -19,6 +19,11 @@ class CustomerBank
     private $postcode;       # string(16)   Postcode.
     private $state;          # string(40)   State.
 
+    public function __construct()
+    {
+        $this->ID = uniqid();
+    }
+
     public function getID()
     {
         return $this->ID;

--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -140,6 +140,7 @@ class InvoicesDocument extends \DOMDocument
 
             // Make a new line element, and add to <lines>
             $lineElement = $this->createElement('line');
+            $lineElementt->setAttribute('id', $transactionLine->getID());
             $linesElement->appendChild($lineElement);
 
             // Go through each element and use the assigned method

--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -140,7 +140,7 @@ class InvoicesDocument extends \DOMDocument
 
             // Make a new line element, and add to <lines>
             $lineElement = $this->createElement('line');
-            $lineElement->setAttribute('id', $transactionLine->getID());
+            $lineElement->setAttribute('id', $line->getID());
             $linesElement->appendChild($lineElement);
 
             // Go through each element and use the assigned method

--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -140,7 +140,7 @@ class InvoicesDocument extends \DOMDocument
 
             // Make a new line element, and add to <lines>
             $lineElement = $this->createElement('line');
-            $lineElementt->setAttribute('id', $transactionLine->getID());
+            $lineElement->setAttribute('id', $transactionLine->getID());
             $linesElement->appendChild($lineElement);
 
             // Go through each element and use the assigned method

--- a/src/Pronamic/Twinfield/Invoice/InvoiceLine.php
+++ b/src/Pronamic/Twinfield/Invoice/InvoiceLine.php
@@ -36,6 +36,12 @@ class InvoiceLine
         return $this->ID;
     }
 
+    public function setID($ID)
+    {
+        $this->ID = $ID;
+        return $this;
+    }
+
     public function getQuantity()
     {
         return $this->quantity;

--- a/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
+++ b/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
@@ -97,6 +97,8 @@ class InvoiceMapper
         foreach ($responseDOM->getElementsByTagName('line') as $lineDOM) {
             $temp_line = new InvoiceLine();
 
+            $temp_line->setID($lineDOM->getAttribute('id'));
+
             foreach ($lineTags as $tag => $method) {
                 $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
 

--- a/src/Pronamic/Twinfield/Transaction/DOM/TransactionsDocument.php
+++ b/src/Pronamic/Twinfield/Transaction/DOM/TransactionsDocument.php
@@ -75,6 +75,7 @@ class TransactionsDocument extends \DOMDocument
 
             $lineElement = $this->createElement('line');
             $lineElement->setAttribute('type', $transactionLine->getType());
+            $lineElement->setAttribute('id', $transactionLine->getID());
             $linesElement->appendChild($lineElement);
 
             $dim1Element = $this->createElement('dim1', $transactionLine->getDim1());

--- a/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
+++ b/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
@@ -70,10 +70,13 @@ class TransactionMapper
         
         foreach ($responseDOM->getElementsByTagName('line') as $lineDOM) {
             $temp_line = new TransactionLine();
-            
+
             $lineType = $lineDOM->getAttribute('type');
             $temp_line->setType($lineType);
-            
+
+            $lineID = $lineDOM->getAttribute('id');
+            $temp_line->setID($lineID);
+
             foreach ($lineTags as $tag => $method) {
                 $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
                 

--- a/src/Pronamic/Twinfield/Transaction/Transaction.php
+++ b/src/Pronamic/Twinfield/Transaction/Transaction.php
@@ -36,13 +36,23 @@ class Transaction
      */
     public function addLine(TransactionLine $line)
     {
-        array_push($this->lines, $line);
+        $this->lines[$line->getID()] = $line;
         return $this;
     }
 
     public function getLines()
     {
         return $this->lines;
+    }
+
+    public function removeLine($index)
+    {
+        if(array_key_exists($index, $this->lines)){
+            unset($this->lines[$index]);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function getDestiny()

--- a/src/Pronamic/Twinfield/Transaction/TransactionLine.php
+++ b/src/Pronamic/Twinfield/Transaction/TransactionLine.php
@@ -45,6 +45,12 @@ class TransactionLine
         return $this->ID;
     }
 
+    public function setID($ID)
+    {
+        $this->ID = $ID;
+        return $this;
+    }
+
     public function getType()
     {
         return $this->type;

--- a/src/Pronamic/Twinfield/Transaction/TransactionLine.php
+++ b/src/Pronamic/Twinfield/Transaction/TransactionLine.php
@@ -8,8 +8,8 @@ namespace Pronamic\Twinfield\Transaction;
  */
 class TransactionLine
 {
+    private $ID;
     private $type;
-    
     private $dim1;
     private $dim2;
     private $value;
@@ -34,6 +34,16 @@ class TransactionLine
     
     const PERFORMANCETYPE_SERVICES = 'services';
     const PERFORMANCETYPE_GOODS = 'goods';
+
+    public function __construct()
+    {
+        $this->ID = uniqid();
+    }
+
+    public function getID()
+    {
+        return $this->ID;
+    }
 
     public function getType()
     {


### PR DESCRIPTION
Added remove{Type} methods for all sub-objects inserted into an array in the main object. Also if it wasn't already the case and a ID value was required by Twinfield, it is now added to the sub-object. This is also handeled in the DOM and Mapper object.

The CustomerBank object also had a getID() method and sets a uniqid() upon construction.

Al of this to make the remove{Type} functionality work as expected