### PR TITLE
Allow for multiple transactions to be posted, individual results and warning messages

### DIFF
--- a/src/Pronamic/Twinfield/BaseObject.php
+++ b/src/Pronamic/Twinfield/BaseObject.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pronamic\Twinfield;
+
+use Pronamic\Twinfield\Message\Message;
+
+/**
+ * Twinfield Base object.
+ *
+ * @author Jop peters <jop@mastercoding.nl>
+ */
+abstract class BaseObject
+{
+    private $result;
+    private $messages;
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    public function setResult($result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    public function getMessages()
+    {
+        return $this->messages;
+    }
+
+    public function addMessage(Message $message)
+    {
+        $this->messages[] = $message;
+
+        return $this;
+    }
+    public function setMessages($messages)
+    {
+        $this->messages = $messages;
+
+        return $this;
+    }
+
+    public function hasMessages()
+    {
+        return count($this->messages) > 0;
+    }
+}

--- a/src/Pronamic/Twinfield/Message/Message.php
+++ b/src/Pronamic/Twinfield/Message/Message.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Pronamic\Twinfield\Message;
+
+class Message
+{
+    const TYPE_WARNING = 'warning';
+    const TYPE_ERROR = 'error';
+
+    /**
+     * The message type, see type constants.
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
+     * The actual textual message.
+     *
+     * @var string
+     */
+    private $message;
+
+    /**
+     * The field the message belongs to.
+     *
+     * @var string
+     */
+    private $field;
+
+    /**
+     * Gets the The message type, see type constants.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets the The message type, see type constants.
+     *
+     * @param string $type the type
+     *
+     * @return self
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Gets the The actual textual message.
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Sets the The actual textual message.
+     *
+     * @param string $message the message
+     *
+     * @return self
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    /**
+     * Gets the The field the message belongs to.
+     *
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    /**
+     * Sets the The field the message belongs to.
+     *
+     * @param string $field the field
+     *
+     * @return self
+     */
+    public function setField($field)
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+}

--- a/src/Pronamic/Twinfield/Response/Response.php
+++ b/src/Pronamic/Twinfield/Response/Response.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Pronamic\Twinfield\Response;
 
 /**
- * Response class
+ * Response class.
  *
  * Handles the response from a request.  Has the option
  * to determine if the response was a success or not.
- * 
+ *
  * Can return an array of error messages retrieved from the response
  *
  * @since 0.0.1
@@ -14,19 +15,17 @@ namespace Pronamic\Twinfield\Response;
  * @uses \DOMDocument
  * @uses \DOMXPath
  *
- * @package Pronamic\Twinfield
- * @subpackage Response
  * @author Leon Rowland <leon@rowland.nl>
  * @copyright (c) 2013, Leon Rowland
+ *
  * @version 0.0.1
  */
 class Response
 {
     /**
      * Holds the response, loaded in from the
-     * \Pronamic\Twinfield\Secure\Service class
+     * \Pronamic\Twinfield\Secure\Service class.
      *
-     * @access private
      * @var \DOMDocument
      */
     private $responseDocument;
@@ -41,7 +40,6 @@ class Response
      *
      * @since 0.0.1
      *
-     * @access public
      * @return \DOMDocument
      */
     public function getResponseDocument()
@@ -55,17 +53,35 @@ class Response
      * attribute result.  If it doesn't equal 1, then it failed.
      *
      * @since 0.0.1
-     *
      * @see http://remcotolsma.nl/wp-content/uploads/Twinfield-Webservices-Manual.pdf
      *
-     * @access public
-     * @return boolean
+     * @return bool
      */
     public function isSuccessful()
     {
         $responseValue = $this->responseDocument->documentElement->getAttribute('result');
 
         return (bool) $responseValue;
+    }
+
+    /**
+     * Will return an array of all messages found by type
+     * in the response document.
+     *
+     * @return array
+     */
+    private function getMessages($type)
+    {
+        $xpath = new \DOMXPath($this->responseDocument);
+
+        $errors = array();
+
+        $rowNodes = $xpath->query('//*[@msgtype="'.$type.'"]');
+        foreach ($rowNodes as $rowNode) {
+            $errors[] = $rowNode->getAttribute('msg');
+        }
+
+        return $errors;
     }
 
     /**
@@ -77,20 +93,26 @@ class Response
      *
      * @since 0.0.1
      *
-     * @access public
      * @return array
      */
     public function getErrorMessages()
     {
-        $xpath = new \DOMXPath($this->responseDocument);
+        return $this->getMessages('error');
+    }
 
-        $errors = array();
-
-        $rowNodes = $xpath->query('//*[@msgtype="error"]');
-        foreach ($rowNodes as $rowNode) {
-            $errors[] = $rowNode->getAttribute('msg');
-        }
-
-        return $errors;
+    /**
+     * Will return an array of all warning messages found
+     * in the response document.
+     *
+     * It is recommended to run this function after a
+     * isSuccessful check.
+     *
+     * @since 0.0.1
+     *
+     * @return array
+     */
+    public function getWarningMessages()
+    {
+        return $this->getMessages('warning');
     }
 }

--- a/src/Pronamic/Twinfield/Secure/Config.php
+++ b/src/Pronamic/Twinfield/Secure/Config.php
@@ -55,6 +55,14 @@ class Config
      */
     private $oauth = null;
 
+
+    /**
+     * Holds the optional soap client options
+     *
+     * @var Array
+     */
+    private $soapClientOptions = array();
+
     /**
      * Sets the oAuth details for this config object.
      *
@@ -239,5 +247,16 @@ class Config
     public function getRedirectURL()
     {
         return $this->oauthCredentials['redirectURL'];
+    }
+
+    public function getSoapClientOptions()
+    {
+        return $this->soapClientOptions;
+    }
+
+    public function setSoapClientOptions(Array $options)
+    {
+        $this->soapClientOptions = $options;
+        return $this;
     }
 }

--- a/src/Pronamic/Twinfield/Secure/Login.php
+++ b/src/Pronamic/Twinfield/Secure/Login.php
@@ -176,7 +176,7 @@ class Login
         }
 
         // Makes a new client, and assigns the header to it
-        $client = new SoapClient(sprintf($this->clusterWSDL, $this->cluster));
+        $client = new SoapClient(sprintf($this->clusterWSDL, $this->cluster), $this->config->getSoapClientOptions());
         $client->__setSoapHeaders($this->getHeader());
 
         return $client;

--- a/src/Pronamic/Twinfield/Transaction/DOM/TransactionsDocument.php
+++ b/src/Pronamic/Twinfield/Transaction/DOM/TransactionsDocument.php
@@ -5,8 +5,8 @@ namespace Pronamic\Twinfield\Transaction\DOM;
 use Pronamic\Twinfield\Transaction\Transaction;
 
 /**
- * TransactionsDocument class
- * 
+ * TransactionsDocument class.
+ *
  * @author Dylan Schoenmakers <dylan@opifer.nl>
  */
 class TransactionsDocument extends \DOMDocument
@@ -14,15 +14,14 @@ class TransactionsDocument extends \DOMDocument
     /**
      * Holds the <transactions> element
      * that all additional elements should be a child of.
+     *
      * @var \DOMElement
      */
     private $transactionsElement;
 
     /**
      * Creates the <transasctions> element and adds it to the property
-     * transactionsElement
-     * 
-     * @access public
+     * transactionsElement.
      */
     public function __construct()
     {
@@ -32,17 +31,14 @@ class TransactionsDocument extends \DOMDocument
         $this->appendChild($this->transactionsElement);
     }
 
-
     /**
      * Turns a passed Transaction class into the required markup for interacting
      * with Twinfield.
-     * 
+     *
      * This method doesn't return anything, instead just adds the transaction
      * to this DOMDocument instance for submission usage.
-     * 
-     * @access public
+     *
      * @param \Pronamic\Twinfield\Transaction\Transaction $transaction
-     * @return void | [Adds to this instance]
      */
     public function addTransaction(Transaction $transaction)
     {
@@ -72,7 +68,6 @@ class TransactionsDocument extends \DOMDocument
 
         // Lines
         foreach ($transaction->getLines() as $transactionLine) {
-
             $lineElement = $this->createElement('line');
             $lineElement->setAttribute('type', $transactionLine->getType());
             $lineElement->setAttribute('id', $transactionLine->getID());
@@ -83,11 +78,11 @@ class TransactionsDocument extends \DOMDocument
             $value = $transactionLine->getValue();
             $value = number_format($value, 2, '.', '');
             $valueElement = $this->createElement('value', $value);
-            
+
             if ($transactionLine->getType() != 'total') {
                 $vatCodeElement = $this->createElement('vatcode', $transactionLine->getVatCode());
             }
-            
+
             $descriptionNode = $this->createTextNode($transactionLine->getDescription());
             $descriptionElement = $this->createElement('description');
             $descriptionElement->appendChild($descriptionNode);
@@ -95,16 +90,21 @@ class TransactionsDocument extends \DOMDocument
             $lineElement->appendChild($dim1Element);
             $lineElement->appendChild($dim2Element);
             $lineElement->appendChild($valueElement);
-            
+
             if (!empty($transactionLine->getPerformanceType())) {
                 $perfElement = $this->createElement('performancetype', $transactionLine->getPerformanceType());
                 $lineElement->appendChild($perfElement);
             }
-            
+
+            if (!empty($transactionLine->getVatValue())) {
+                $vatElement = $this->createElement('vatvalue', $transactionLine->getVatValue());
+                $lineElement->appendChild($vatElement);
+            }
+
             if ($transactionLine->getType() != 'total') {
                 $lineElement->appendChild($vatCodeElement);
             }
-            
+
             $lineElement->appendChild($descriptionElement);
         }
     }

--- a/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
+++ b/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Pronamic\Twinfield\Transaction\Mapper;
 
-use \Pronamic\Twinfield\Transaction\Transaction;
-use \Pronamic\Twinfield\Transaction\TransactionLine;
-use \Pronamic\Twinfield\Response\Response;
+use Pronamic\Twinfield\Transaction\Transaction;
+use Pronamic\Twinfield\Transaction\TransactionLine;
+use Pronamic\Twinfield\Response\Response;
+use Pronamic\Twinfield\Message\Message;
 
 class TransactionMapper
 {
@@ -14,82 +16,105 @@ class TransactionMapper
 
         // All tags for the transaction
         $transactionTags = array(
-            'code'          => 'setCode',
-            'currency'      => 'setCurrency',
-            'date'          => 'setDate',
-            'period'        => 'setPeriod',
+            'code' => 'setCode',
+            'currency' => 'setCurrency',
+            'date' => 'setDate',
+            'period' => 'setPeriod',
             'invoicenumber' => 'setInvoiceNumber',
-            'office'        => 'setOffice',
-            'duedate'       => 'setDueDate',
-            'origin'        => 'setOrigin',
-            'number'        => 'setNumber'
+            'office' => 'setOffice',
+            'duedate' => 'setDueDate',
+            'origin' => 'setOrigin',
+            'number' => 'setNumber',
         );
-        
+
         // Make new Transaction Object
-        $transaction = new Transaction();
-        
+        $transactions = array();
+
         // Get the top level transaction element
-        $transactionElement = $responseDOM->getElementsByTagName('transaction')->item(0);
-        
-        // Set the destiny/location
-        $location = $transactionElement->getAttribute('location');
-        $transaction->setDestiny($location);
-        
-        // Set the raise warning
-        $raiseWarning = $transactionElement->getAttribute('raisewarning');
-        $transaction->setRaiseWarning($raiseWarning);
-        
-        // Go through each tag and call the method if a value is set
-        foreach ($transactionTags as $tag => $method) {
-            $_tag = $responseDOM->getElementsByTagName($tag)->item(0);
-            
-            if (isset($_tag) && isset($_tag->textContent)) {
-                $transaction->$method($_tag->textContent);
-            }
-        }
-        
-        $lineTags = array(
-            'dim1'             => 'setDim1',
-            'dim2'             => 'setDim2',
-            'value'            => 'setValue',
-            'debitcredit'      => 'setDebitCredit',
-            'description'      => 'setDescription',
-            'rate'             => 'setRate',
-            'basevalue'        => 'setBaseValue',
-            'reprate'          => 'setRepRate',
-            'vatcode'          => 'setVatCode',
-            'vattotal'         => 'setVatTotal',
-            'vatbasetotal'     => 'setVatBaseTotal',
-            'customersupplier' => 'setCustomerSupplier',
-            'openvalue'        => 'setOpenValue',
-            'openbasevalue'    => 'setOpenBaseValue',
-            'repvalue'         => 'setRepValue',
-            'matchlevel'       => 'setMatchLevel',
-            'matchstatus'      => 'setMatchStatus'
-        );
-        
-        foreach ($responseDOM->getElementsByTagName('line') as $lineDOM) {
-            $temp_line = new TransactionLine();
+        $transactionElements = $responseDOM->getElementsByTagName('transaction');
+        foreach ($transactionElements as $transactionElement) {
 
-            $lineType = $lineDOM->getAttribute('type');
-            $temp_line->setType($lineType);
+            // create new transaction
+            $transaction = new Transaction();
 
-            $lineID = $lineDOM->getAttribute('id');
-            $temp_line->setID($lineID);
+            // set the result
+            $result = $transactionElement->getAttribute('result');
+            $transaction->setResult($result);
 
-            foreach ($lineTags as $tag => $method) {
-                $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
-                
+            // Set the destiny/location
+            $location = $transactionElement->getAttribute('location');
+            $transaction->setDestiny($location);
+
+            // Set the raise warning
+            $raiseWarning = $transactionElement->getAttribute('raisewarning');
+            $transaction->setRaiseWarning($raiseWarning);
+
+            // Go through each tag and call the method if a value is set
+            foreach ($transactionTags as $tag => $method) {
+                $_tag = $transactionElement->getElementsByTagName($tag)->item(0);
+
                 if (isset($_tag) && isset($_tag->textContent)) {
-                    $temp_line->$method($_tag->textContent);
+                    $transaction->$method($_tag->textContent);
+                }
+
+                // msg
+                if (isset($_tag) && $_tag->hasAttribute('msg')) {
+                    $message = new Message();
+                    $message->setType($_tag->getAttribute('msgtype'));
+                    $message->setMessage($_tag->getAttribute('msg'));
+                    $message->setField($tag);
+                    $transaction->addMessage($message);
                 }
             }
-            
-            $transaction->addLine($temp_line);
-            unset($lineType);
-            unset($temp_line);
+
+            $lineTags = array(
+                'dim1' => 'setDim1',
+                'dim2' => 'setDim2',
+                'value' => 'setValue',
+                'debitcredit' => 'setDebitCredit',
+                'description' => 'setDescription',
+                'rate' => 'setRate',
+                'basevalue' => 'setBaseValue',
+                'reprate' => 'setRepRate',
+                'vatcode' => 'setVatCode',
+                'vattotal' => 'setVatTotal',
+                'vatvalue' => 'setVatValue',
+                'vatbasetotal' => 'setVatBaseTotal',
+                'customersupplier' => 'setCustomerSupplier',
+                'openvalue' => 'setOpenValue',
+                'openbasevalue' => 'setOpenBaseValue',
+                'repvalue' => 'setRepValue',
+                'matchlevel' => 'setMatchLevel',
+                'matchstatus' => 'setMatchStatus',
+            );
+
+            foreach ($transactionElement->getElementsByTagName('line') as $lineDOM) {
+                $temp_line = new TransactionLine();
+
+                $lineType = $lineDOM->getAttribute('type');
+                $temp_line->setType($lineType);
+
+                $lineID = $lineDOM->getAttribute('id');
+                $temp_line->setID($lineID);
+
+                foreach ($lineTags as $tag => $method) {
+                    $_tag = $lineDOM->getElementsByTagName($tag)->item(0);
+
+                    if (isset($_tag) && isset($_tag->textContent)) {
+                        $temp_line->$method($_tag->textContent);
+                    }
+                }
+
+                $transaction->addLine($temp_line);
+                unset($lineType);
+                unset($temp_line);
+            }
+
+            // add
+            $transactions[] = $transaction;
         }
-        
-        return $transaction;
+
+        // for backwards compatibility, return only the first instance if there is only one
+        return count($transactions) == 1 ? $transactions[0] : $transactions;
     }
 }

--- a/src/Pronamic/Twinfield/Transaction/Transaction.php
+++ b/src/Pronamic/Twinfield/Transaction/Transaction.php
@@ -2,12 +2,14 @@
 
 namespace Pronamic\Twinfield\Transaction;
 
+use Pronamic\Twinfield\BaseObject;
+
 /**
- * Transaction class
- * 
+ * Transaction class.
+ *
  * @author Dylan Schoenmakers <dylan@opifer.nl>
  */
-class Transaction
+class Transaction extends BaseObject
 {
     private $raiseWarning;
     private $destiny;
@@ -17,9 +19,8 @@ class Transaction
     private $date;
     private $period;
     private $origin;
-    
+
     /**
-     *
      * @var \Pronamic\Twinfield\Customer\Customer
      */
     private $customer;
@@ -29,14 +30,16 @@ class Transaction
     private $lines = array();
 
     /**
-     * Add a TransactionLine to this Transaction
-     * 
+     * Add a TransactionLine to this Transaction.
+     *
      * @param \Pronamic\Twinfield\Transaction\TransactionLine $line
+     *
      * @return \Pronamic\Twinfield\Transaction\Transaction
      */
     public function addLine(TransactionLine $line)
     {
         $this->lines[$line->getID()] = $line;
+
         return $this;
     }
 
@@ -49,6 +52,7 @@ class Transaction
     {
         if (array_key_exists($index, $this->lines)) {
             unset($this->lines[$index]);
+
             return true;
         } else {
             return false;
@@ -63,6 +67,7 @@ class Transaction
     public function setDestiny($destiny)
     {
         $this->destiny = $destiny;
+
         return $this;
     }
 
@@ -74,6 +79,7 @@ class Transaction
     public function setOffice($office)
     {
         $this->office = $office;
+
         return $this;
     }
 
@@ -85,6 +91,7 @@ class Transaction
     public function setCode($code)
     {
         $this->code = $code;
+
         return $this;
     }
 
@@ -96,6 +103,7 @@ class Transaction
     public function setDate($date)
     {
         $this->date = $date;
+
         return $this;
     }
 
@@ -107,6 +115,7 @@ class Transaction
     public function setDueDate($dueDate)
     {
         $this->dueDate = $dueDate;
+
         return $this;
     }
 
@@ -118,9 +127,10 @@ class Transaction
     public function setInvoiceNumber($invoiceNumber)
     {
         $this->invoiceNumber = $invoiceNumber;
+
         return $this;
     }
-    
+
     public function getRaiseWarning()
     {
         return $this->raiseWarning;
@@ -129,6 +139,7 @@ class Transaction
     public function setRaiseWarning($raiseWarning)
     {
         $this->raiseWarning = $raiseWarning;
+
         return $this;
     }
 
@@ -140,6 +151,7 @@ class Transaction
     public function setPeriod($period)
     {
         $this->period = $period;
+
         return $this;
     }
 
@@ -151,6 +163,7 @@ class Transaction
     public function setOrigin($origin)
     {
         $this->origin = $origin;
+
         return $this;
     }
 
@@ -162,9 +175,10 @@ class Transaction
     public function setCustomer(\Pronamic\Twinfield\Customer\Customer $customer)
     {
         $this->customer = $customer;
+
         return $this;
     }
-    
+
     public function getCurrency()
     {
         return $this->currency;
@@ -173,9 +187,10 @@ class Transaction
     public function setCurrency($currency)
     {
         $this->currency = $currency;
+
         return $this;
     }
-    
+
     public function getNumber()
     {
         return $this->number;
@@ -184,6 +199,7 @@ class Transaction
     public function setNumber($number)
     {
         $this->number = $number;
+
         return $this;
     }
 }

--- a/src/Pronamic/Twinfield/Transaction/TransactionFactory.php
+++ b/src/Pronamic/Twinfield/Transaction/TransactionFactory.php
@@ -2,39 +2,38 @@
 
 namespace Pronamic\Twinfield\Transaction;
 
-use \Pronamic\Twinfield\Factory\ParentFactory;
-use \Pronamic\Twinfield\Request as Request;
+use Pronamic\Twinfield\Factory\ParentFactory;
+use Pronamic\Twinfield\Request as Request;
 
 /**
- * TransactionFactory class
- * 
+ * TransactionFactory class.
+ *
  * @author Dylan Schoenmakers <dylan@opifer.nl>
  */
 class TransactionFactory extends ParentFactory
 {
-    
     public function get($code, $number, $office = null)
     {
         if ($this->getLogin()->process()) {
-            
+
             // Get the secure service
             $service = $this->getService();
-            
+
             if (!$office) {
                 $office = $this->getConfig()->getOffice();
             }
-            
+
             // Make a request to read a single transaction
             $request_transaction = new Request\Read\Transaction();
             $request_transaction
                 ->setCode($code)
                 ->setNumber($number)
                 ->setOffice($office);
-            
+
             // Send the Request document and set the response to this instance
             $response = $service->send($request_transaction);
             $this->setResponse($response);
-            
+
             if ($response->isSuccessful()) {
                 return Mapper\TransactionMapper::map($response);
             } else {
@@ -44,19 +43,26 @@ class TransactionFactory extends ParentFactory
     }
 
     /**
-     * 
-     * @param \Pronamic\Twinfield\Transaction\Transaction $transaction
-     * @return boolean
+     * @param \Pronamic\Twinfield\Transaction\Transaction $transaction|Array Either one instance or an array of transaction instances
+     *
+     * @return bool
      */
-    public function send(Transaction $transaction)
+    public function send($transaction)
     {
         if ($this->getLogin()->process()) {
-            
+
             // Gets the secure service
             $service = $this->getService();
 
             $transactionsDocument = new DOM\TransactionsDocument();
-            $transactionsDocument->addTransaction($transaction);
+
+            if (is_array($transaction)) {
+                foreach ($transaction as $t) {
+                    $transactionsDocument->addTransaction($t);
+                }
+            } else {
+                $transactionsDocument->addTransaction($transaction);
+            }
 
             // Send the DOM document request and set the response
             $response = $service->send($transactionsDocument);

--- a/src/Pronamic/Twinfield/Transaction/TransactionLine.php
+++ b/src/Pronamic/Twinfield/Transaction/TransactionLine.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Pronamic\Twinfield\Transaction;
 
 /**
- * TransactionLine class
- * 
+ * TransactionLine class.
+ *
  * @author Dylan Schoenmakers <dylan@opifer.nl>
  */
 class TransactionLine
@@ -20,6 +21,7 @@ class TransactionLine
     private $baseValue;
     private $repRate;
     private $repValue;
+    private $vatValue;
     private $vatTotal;
     private $vatBaseTotal;
     private $performanceType;
@@ -31,7 +33,7 @@ class TransactionLine
     private $openValue;
     private $openBaseValue;
     private $matchStatus;
-    
+
     const PERFORMANCETYPE_SERVICES = 'services';
     const PERFORMANCETYPE_GOODS = 'goods';
 
@@ -48,6 +50,7 @@ class TransactionLine
     public function setID($ID)
     {
         $this->ID = $ID;
+
         return $this;
     }
 
@@ -59,6 +62,7 @@ class TransactionLine
     public function setType($type)
     {
         $this->type = $type;
+
         return $this;
     }
 
@@ -70,6 +74,7 @@ class TransactionLine
     public function setDim1($dim1)
     {
         $this->dim1 = $dim1;
+
         return $this;
     }
 
@@ -81,6 +86,7 @@ class TransactionLine
     public function setDim2($dim2)
     {
         $this->dim2 = $dim2;
+
         return $this;
     }
 
@@ -92,6 +98,7 @@ class TransactionLine
     public function setValue($value)
     {
         $this->value = $value;
+
         return $this;
     }
 
@@ -103,6 +110,7 @@ class TransactionLine
     public function setVatCode($vatCode)
     {
         $this->vatCode = $vatCode;
+
         return $this;
     }
 
@@ -110,10 +118,11 @@ class TransactionLine
     {
         return $this->debitCredit;
     }
-    
+
     public function setDebitCredit($debitCredit)
     {
         $this->debitCredit = $debitCredit;
+
         return $this;
     }
 
@@ -125,6 +134,7 @@ class TransactionLine
     public function setDescription($description)
     {
         $this->description = $description;
+
         return $this;
     }
 
@@ -136,6 +146,7 @@ class TransactionLine
     public function setRate($rate)
     {
         $this->rate = $rate;
+
         return $this;
     }
 
@@ -147,6 +158,7 @@ class TransactionLine
     public function setBaseValue($baseValue)
     {
         $this->baseValue = $baseValue;
+
         return $this;
     }
 
@@ -158,6 +170,7 @@ class TransactionLine
     public function setRepRate($repRate)
     {
         $this->repRate = $repRate;
+
         return $this;
     }
 
@@ -169,6 +182,19 @@ class TransactionLine
     public function setRepValue($repValue)
     {
         $this->repValue = $repValue;
+
+        return $this;
+    }
+
+    public function getVatValue()
+    {
+        return $this->vatValue;
+    }
+
+    public function setVatValue($vatValue)
+    {
+        $this->vatValue = $vatValue;
+
         return $this;
     }
 
@@ -180,6 +206,7 @@ class TransactionLine
     public function setVatTotal($vatTotal)
     {
         $this->vatTotal = $vatTotal;
+
         return $this;
     }
 
@@ -191,9 +218,10 @@ class TransactionLine
     public function setVatBaseTotal($vatBaseTotal)
     {
         $this->vatBaseTotal = $vatBaseTotal;
+
         return $this;
     }
-    
+
     public function getPerformanceType()
     {
         return $this->performanceType;
@@ -202,6 +230,7 @@ class TransactionLine
     public function setPerformanceType($performanceType)
     {
         $this->performanceType = $performanceType;
+
         return $this;
     }
 
@@ -213,6 +242,7 @@ class TransactionLine
     public function setPerformanceCountry($performanceCountry)
     {
         $this->performanceCountry = $performanceCountry;
+
         return $this;
     }
 
@@ -224,6 +254,7 @@ class TransactionLine
     public function setPerformanceVatNumber($performanceVatNumber)
     {
         $this->performanceVatNumber = $performanceVatNumber;
+
         return $this;
     }
 
@@ -235,6 +266,7 @@ class TransactionLine
     public function setPerformanceDate($performanceDate)
     {
         $this->performanceDate = $performanceDate;
+
         return $this;
     }
 
@@ -246,6 +278,7 @@ class TransactionLine
     public function setMatchLevel($matchLevel)
     {
         $this->matchLevel = $matchLevel;
+
         return $this;
     }
 
@@ -257,6 +290,7 @@ class TransactionLine
     public function setCustomerSupplier($customerSupplier)
     {
         $this->customerSupplier = $customerSupplier;
+
         return $this;
     }
 
@@ -268,6 +302,7 @@ class TransactionLine
     public function setOpenValue($openValue)
     {
         $this->openValue = $openValue;
+
         return $this;
     }
 
@@ -279,6 +314,7 @@ class TransactionLine
     public function setOpenBaseValue($openBaseValue)
     {
         $this->openBaseValue = $openBaseValue;
+
         return $this;
     }
 
@@ -290,6 +326,7 @@ class TransactionLine
     public function setMatchStatus($matchStatus)
     {
         $this->matchStatus = $matchStatus;
+
         return $this;
     }
 }


### PR DESCRIPTION
I created the foundation to allow for the possibility to send multiple transactions, customers, etc. in one request. I implemented this for transactions only. This behaviour can be duplicated to customers and all other components as well, but i'd like your feedback before doing so.

There should not be any BC breaks, I made sure to keep the behaviour for one transaction the way it is right now.