### PR TITLE
Added FinderFactory, UserFactory and OfficeFactory.

### DIFF
--- a/src/Pronamic/Twinfield/Factory/FinderFactory.php
+++ b/src/Pronamic/Twinfield/Factory/FinderFactory.php
@@ -1,0 +1,108 @@
+<?php
+namespace Pronamic\Twinfield\Factory;
+
+/**
+ * Use the finder web service in order to get all kind of master data from Twinfield.
+ *
+ * @note Since it is not possible to add the company code to the finder, make sure the correct company is set by using
+ * either the SelectCompany function or adding the office option.
+ *
+ * @see https://c3.twinfield.com/webservices/documentation/#/ApiReference/Miscellaneous/Finder
+ *
+ * @author Emile Bons <emile@emilebons.nl>
+ * @package Pronamic\Twinfield
+ */
+abstract class FinderFactory extends ParentFactory
+{
+	const SEARCH_FIELD_CODE_OR_NAME = 0;
+	const SEARCH_FIELD_CODE = 1;
+	const SEARCH_FIELD_NAME = 2;
+	const SEARCH_FIELD_DIMENSIONS_BANK_ACCOUNT_NUMBER = 3;
+	const SEARCH_FIELD_DIMENSIONS_ADDRESS = 4;
+	const SEARCH_FIELD_CUSTOMER_CODE = 3;
+	const SEARCH_FIELD_DIMENSION_CODE_OR_NAME_INVOICE_AMOUNT_INVOICE_NUMBER = 0;
+    const TYPE_ITEMS = 'ART';
+    const TYPE_ASSET_METHODS = 'ASM';
+    const TYPE_BUDGETS = 'BDS';
+    const TYPE_CASHBOOKS_AND_BANKS = 'BNK';
+    const TYPE_BILLING_SCHEDULE = 'BSN';
+    const TYPE_CREDIT_MANAGEMENT_ACTION_CODES = 'CDA';
+    const TYPE_CERTIFICATES = 'CER';
+    const TYPE_LIST_OF_AVAILABLE_CHEQUES = 'CQT';
+    const TYPE_COUNTRIES = 'CTR';
+    const TYPE_CURRENCIES = 'CUR';
+    const TYPE_DIMENSIONS_FINANCIALS = 'DIM';
+    const TYPE_DIMENSIONS_MODIFIED_SINCE_OPTION = 'DIM';
+    const TYPE_DIMENSIONS_PROJECTS = 'DIM';
+    const TYPE_DIMENSION_TYPES = 'DMT';
+    const TYPE_VAT_TYPES = 'DVT';
+    const TYPE_FILTER_MAPPINGS = 'FLT';
+    const TYPE_PAYMENT_FILES = 'FMT';
+    const TYPE_DIMENSION_GROUPS = 'GRP';
+    const TYPE_GATEWAYS = 'GWY';
+    const TYPE_HIERARCHIES = 'HIE';
+    const TYPE_HIERARCHY_NODES = 'HND';
+    const TYPE_INVOICE_TYPES = 'INV';
+    const TYPE_LIST_OF_AVAILABLE_INVOICES = 'IVT';
+    const TYPE_MATCHING_TYPES = 'MAT';
+    const TYPE_OFFICES = 'OFF';
+    const TYPE_OFFICE_GROUPS = 'OFG';
+    const TYPE_AVAILABLE_OFFICES_FOR_INTER_COMPANY_TRANSACTIONS = 'OIC';
+    const TYPE_PAYMENT_TYPES = 'PAY';
+    const TYPE_PAYING_IN_SLIPS = 'PIS';
+    const TYPE_PERIODS = 'PRD';
+    const TYPE_REPORTS = 'REP';
+    const TYPE_WORD_TEMPLATES = 'REW';
+    const TYPE_REMINDER_SCENARIOS = 'RMD';
+    const TYPE_USER_ROLES = 'ROL';
+    const TYPE_SUB_ITEMS = 'SAR';
+    const TYPE_DISTRIBUTION_BY_PERIODS = 'SPM';
+    const TYPE_TAX_GROUPS = 'TXG';
+    const TYPE_TIME_QUANTITIES_TRANSACTION_TYPES = 'TEQ';
+    const TYPE_TRANSACTION_TYPES = 'TRS';
+    const TYPE_TIME_PROJECT_RATES = 'TRT';
+    const TYPE_USERS = 'USR';
+    const TYPE_VAT_CODES = 'VAT';
+    const TYPE_VAT_NUMBERS_OF_RELATIONS = 'VATN';
+    const TYPE_VAT_GROUPS = 'VTB';
+    const TYPE_VAT_GROUPS_COUNTRIES = 'VGM';
+    const TYPE_TRANSLATIONS = 'XLT';
+
+
+	/**
+	 * @var string the WSDL location of the finder service
+	 */
+	private $wsdl = '/webservices/finder.asmx?wsdl';
+
+	/**
+	 * @return \SoapClient the finder web service. Used to get all kind of master data from Twinfield.
+	 */
+	private function getFinder()
+	{
+		return $this->getClient($this->wsdl);
+	}
+
+	/**
+	 * @param string $type Finder type, see Finder type.
+	 * @param string $pattern The search pattern. May contain wildcards * and ?
+	 * @param int $field The search field determines which field or fields will be searched. The available fields
+	 * depends on the finder type. Passing a value outside the specified values will cause an error.
+	 * @param int $firstRow First row to return, useful for paging
+	 * @param int $maxRows Maximum number of rows to return, useful for paging
+	 * @param array $options The Finder options. Passing an unsupported name or value causes an error. It's possible to
+	 * add multiple options. An option name may be used once, specifying an option multiple times will cause an error.
+	 * @return mixed the search results
+	 */
+	public function searchFinder($type, $pattern = '*', $field = 0, $firstRow = 1, $maxRows = 100, $options = array())
+	{
+		return $this->getFinder()->Search([
+			'type' => $type,
+			'pattern' => $pattern,
+			'field' => $field,
+			'firstRow' => $firstRow,
+			'maxRows' => $maxRows,
+			'options' => $options,
+		]);
+	}
+
+}

--- a/src/Pronamic/Twinfield/Factory/ParentFactory.php
+++ b/src/Pronamic/Twinfield/Factory/ParentFactory.php
@@ -66,6 +66,15 @@ abstract class ParentFactory
         return $this;
     }
 
+	/**
+	 * @param string $wsdl the resource location
+	 * @return \SoapClient
+	 */
+	public function getClient($wsdl)
+	{
+		return $this->getLogin()->getClient('%s'.$wsdl);
+	}
+
     /**
      * Returns this instances Secure\Config instance.
      * 

--- a/src/Pronamic/Twinfield/Office/Office.php
+++ b/src/Pronamic/Twinfield/Office/Office.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pronamic\Twinfield\Office;
+
+class Office
+{
+    /**
+     * @var string the code of the office
+     */
+    private $code;
+    /**
+     * @var string the code of the country of the office
+     */
+    private $countryCode;
+    /**
+     * @var string the name of the office
+     */
+    private $name;
+
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    public function getCountryCode()
+    {
+        return $this->countryCode;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    public function setCountryCode($countryCode)
+    {
+        $this->countryCode = $countryCode;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Pronamic/Twinfield/Office/OfficeFactory.php
+++ b/src/Pronamic/Twinfield/Office/OfficeFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pronamic\Twinfield\Office;
+
+use Pronamic\Twinfield\Factory\FinderFactory;
+
+/**
+ * OfficeFactory
+ *
+ * A facade factory to make interaction with the the twinfield service easier
+ * when trying to retrieve or send information about offices.
+ *
+ * If you require more complex interactions or a heavier amount of control
+ * over the requests to/from then look inside the methods or see
+ * the advanced guide detailing the required usages.
+ *
+ * @package Pronamic\Twinfield
+ * @subpackage Office
+ * @author Emile Bons <emile@emilebons.nl>
+ */
+class OfficeFactory extends FinderFactory
+{
+    /**
+     * List all offices.
+     * @param string $pattern The search pattern. May contain wildcards * and ?
+     * @param int $field The search field determines which field or fields will be searched. The available fields
+     * depends on the finder type. Passing a value outside the specified values will cause an error.
+     * @param int $firstRow First row to return, useful for paging
+     * @param int $maxRows Maximum number of rows to return, useful for paging
+     * @param array $options The Finder options. Passing an unsupported name or value causes an error. It's possible to
+     * add multiple options. An option name may be used once, specifying an option multiple times will cause an error.
+     * @return Office[] the offices found
+     */
+    public function listAll($pattern = '*', $field = 0, $firstRow = 1, $maxRows = 100, $options = array())
+    {
+        $response = $this->searchFinder(self::TYPE_OFFICES, $pattern, $field, $firstRow, $maxRows, $options);
+        $offices = [];
+        foreach($response->data->Items->ArrayOfString as $officeArray)
+        {
+            $office = new Office();
+            $office->setCode($officeArray->string[0]);
+            $office->setCountryCode($officeArray->string[2]);
+            $office->setName($officeArray->string[1]);
+            $offices[] = $office;
+        }
+        return $offices;
+    }
+}

--- a/src/Pronamic/Twinfield/Secure/Login.php
+++ b/src/Pronamic/Twinfield/Secure/Login.php
@@ -62,7 +62,7 @@ class Login
      * @access private
      * @var string
      */
-    private $sessionID;
+    public $sessionID;
 
     /**
      * The server cluster used for future XML
@@ -71,7 +71,7 @@ class Login
      * @access private
      * @var string
      */
-    private $cluster;
+    public $cluster;
 
     /**
      * If the login has been processed and was
@@ -161,21 +161,23 @@ class Login
     /**
      * Gets the soap client with the headers attached
      *
-     * Will automaticly login if haven't already on this instance
+     * Will automatically login if haven't already on this instance
      *
      * @since 0.0.1
      *
+	 * @param string|null $wsdl the wsdl to use. If null, the clusterWSDL is used.
      * @access public
      * @return \SoapClient
      */
-    public function getClient()
+    public function getClient($wsdl = null)
     {
         if (! $this->processed) {
             $this->process();
         }
+		$wsdl = is_null($wsdl) ? $this->clusterWSDL : $wsdl;
 
         // Makes a new client, and assigns the header to it
-        $client = new SoapClient(sprintf($this->clusterWSDL, $this->cluster), $this->config->getSoapClientOptions());
+        $client = new SoapClient(sprintf($wsdl, $this->cluster), $this->config->getSoapClientOptions());
         $client->__setSoapHeaders($this->getHeader());
 
         return $client;

--- a/src/Pronamic/Twinfield/User/User.php
+++ b/src/Pronamic/Twinfield/User/User.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pronamic\Twinfield\User;
+
+
+class User
+{
+    /**
+     * @var string the code of the user
+     */
+    private $code;
+    /**
+     * @var string the name of the user
+     */
+    private $name;
+
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+}

--- a/src/Pronamic/Twinfield/User/UserFactory.php
+++ b/src/Pronamic/Twinfield/User/UserFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Pronamic\Twinfield\User;
+
+use Pronamic\Twinfield\Factory\FinderFactory;
+use \Pronamic\Twinfield\Request as Request;
+
+/**
+ * UserFactory
+ * 
+ * A facade factory to make interaction with the the twinfield service easier
+ * when trying to retrieve or send information about Users.
+ * 
+ * If you require more complex interactions or a heavier amount of control
+ * over the requests to/from then look inside the methods or see
+ * the advanced guide detailing the required usages.
+ * 
+ * @package Pronamic\Twinfield
+ * @subpackage User
+ * @author Emile Bons <emile@emilebons.nl>
+ */
+class UserFactory extends FinderFactory
+{
+    const ACCESS_RULES_DISABLED = 0;
+    const ACCESS_RULES_ENABLED = 1;
+    const MUTUAL_OFFICES_DISABLED = 0;
+    const MUTUAL_OFFICES_ENABLED = 1;
+
+	public function listAllUsers($officeCode = null, $accessRules = null, $mutualOffices = null, $pattern = '*',
+        $field = 0, $firstRow = 1, $maxRows = 100, $options = array())
+	{
+        if(!is_null($officeCode)) {
+            $options['office'] = $officeCode;
+        }
+        if(!is_null($accessRules)) {
+            $options['accessRules'] = $accessRules;
+        }
+        if(!is_null($mutualOffices)) {
+            $options['mutualOffices'] = $mutualOffices;
+        }
+		$response = $this->searchFinder(self::TYPE_USERS, $pattern, $field, $firstRow, $maxRows, $options);
+        $users = [];
+        foreach($response->data->Items->ArrayOfString as $userArray)
+        {
+            $user = new User();
+            $user->setCode($userArray->string[0]);
+            $user->setName($userArray->string[1]);
+            $users[] = $user;
+        }
+        return $users;
+	}
+}

--- a/src/Pronamic/Twinfield/User/UserFactory.php
+++ b/src/Pronamic/Twinfield/User/UserFactory.php
@@ -26,7 +26,21 @@ class UserFactory extends FinderFactory
     const MUTUAL_OFFICES_DISABLED = 0;
     const MUTUAL_OFFICES_ENABLED = 1;
 
-	public function listAllUsers($officeCode = null, $accessRules = null, $mutualOffices = null, $pattern = '*',
+    /**
+     * List all users.
+     * @param string $officeCode the office code, if only users from one office should be listed
+     * @param integer $accessRules
+     * @param integer $mutualOffices
+     * @param string $pattern The search pattern. May contain wildcards * and ?
+     * @param int $field The search field determines which field or fields will be searched. The available fields
+     * depends on the finder type. Passing a value outside the specified values will cause an error.
+     * @param int $firstRow First row to return, useful for paging
+     * @param int $maxRows Maximum number of rows to return, useful for paging
+     * @param array $options The Finder options. Passing an unsupported name or value causes an error. It's possible to
+     * add multiple options. An option name may be used once, specifying an option multiple times will cause an error.
+     * @return User[] the users found
+     */
+	public function listAll($officeCode = null, $accessRules = null, $mutualOffices = null, $pattern = '*',
         $field = 0, $firstRow = 1, $maxRows = 100, $options = array())
 	{
         if(!is_null($officeCode)) {


### PR DESCRIPTION
Several types of objects (including users and offices) require the use of the finder webservice. I wrote a FinderFactory to access the finder webservice and implemented the FinderFactory in UserFactory and OfficeFactory. I included a User class and Office class for retrieving and setting their attributes.

Why are classes written using private properties with getters and setters and not just public properties?