### PR TITLE
Added extra lines to support freetext and added the valueOpen

### DIFF
--- a/src/Pronamic/Twinfield/Customer/CustomerFactory.php
+++ b/src/Pronamic/Twinfield/Customer/CustomerFactory.php
@@ -116,9 +116,10 @@ class CustomerFactory extends ParentFactory
      */
     public function listAll($office = null, $dimType = 'DEB')
     {
+
         // Attempts to process the login
         if ($this->getLogin()->process()) {
-            
+
             // Gets the secure service class
             $service = $this->getService();
 
@@ -126,7 +127,7 @@ class CustomerFactory extends ParentFactory
             if (! $office) {
                 $office = $this->getConfig()->getOffice();
             }
-            
+
             // Make a request to a list of all customers
             $request_customers = new Request\Catalog\Dimension(
                 $office,
@@ -193,7 +194,6 @@ class CustomerFactory extends ParentFactory
     {
         // Attempts the process login
         if ($this->getLogin()->process()) {
-            
             // Gets the secure service
             $service = $this->getService();
 

--- a/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
+++ b/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
@@ -2,36 +2,46 @@
 
 namespace Pronamic\Twinfield\Transaction\Mapper;
 
+use Pronamic\Twinfield\Message\Message;
+use Pronamic\Twinfield\Response\Response;
 use Pronamic\Twinfield\Transaction\Transaction;
 use Pronamic\Twinfield\Transaction\TransactionLine;
-use Pronamic\Twinfield\Response\Response;
-use Pronamic\Twinfield\Message\Message;
 
 class TransactionMapper
 {
+    /**
+     * @param Response $response
+     *
+     * @return Transaction{}
+     */
     public static function map(Response $response)
     {
         // Get the raw DOMDocument response
         $responseDOM = $response->getResponseDocument();
 
         // All tags for the transaction
-        $transactionTags = array(
-            'code' => 'setCode',
-            'currency' => 'setCurrency',
-            'date' => 'setDate',
-            'period' => 'setPeriod',
+        $transactionTags = [
+            'code'          => 'setCode',
+            'currency'      => 'setCurrency',
+            'date'          => 'setDate',
+            'period'        => 'setPeriod',
             'invoicenumber' => 'setInvoiceNumber',
-            'office' => 'setOffice',
-            'duedate' => 'setDueDate',
-            'origin' => 'setOrigin',
-            'number' => 'setNumber',
-        );
+            'office'        => 'setOffice',
+            'duedate'       => 'setDueDate',
+            'origin'        => 'setOrigin',
+            'number'        => 'setNumber',
+            'freetext1'     => 'setFreetext1',
+            'freetext2'     => 'setFreetext2',
+            'freetext3'     => 'setFreetext3',
+        ];
 
         // Make new Transaction Object
-        $transactions = array();
+        $transactions = [];
 
         // Get the top level transaction element
-        $transactionElements = $responseDOM->getElementsByTagName('transaction');
+        $transactionElements
+            = $responseDOM->getElementsByTagName('transaction');
+
         foreach ($transactionElements as $transactionElement) {
 
             // create new transaction
@@ -51,7 +61,8 @@ class TransactionMapper
 
             // Go through each tag and call the method if a value is set
             foreach ($transactionTags as $tag => $method) {
-                $_tag = $transactionElement->getElementsByTagName($tag)->item(0);
+                $_tag = $transactionElement->getElementsByTagName($tag)
+                    ->item(0);
 
                 if (isset($_tag) && isset($_tag->textContent)) {
                     $transaction->$method($_tag->textContent);
@@ -67,28 +78,30 @@ class TransactionMapper
                 }
             }
 
-            $lineTags = array(
-                'dim1' => 'setDim1',
-                'dim2' => 'setDim2',
-                'value' => 'setValue',
-                'debitcredit' => 'setDebitCredit',
-                'description' => 'setDescription',
-                'rate' => 'setRate',
-                'basevalue' => 'setBaseValue',
-                'reprate' => 'setRepRate',
-                'vatcode' => 'setVatCode',
-                'vattotal' => 'setVatTotal',
-                'vatvalue' => 'setVatValue',
-                'vatbasetotal' => 'setVatBaseTotal',
+            $lineTags = [
+                'dim1'             => 'setDim1',
+                'dim2'             => 'setDim2',
+                'value'            => 'setValue',
+                'debitcredit'      => 'setDebitCredit',
+                'description'      => 'setDescription',
+                'rate'             => 'setRate',
+                'basevalue'        => 'setBaseValue',
+                'reprate'          => 'setRepRate',
+                'vatcode'          => 'setVatCode',
+                'vattotal'         => 'setVatTotal',
+                'vatvalue'         => 'setVatValue',
+                'vatbasetotal'     => 'setVatBaseTotal',
                 'customersupplier' => 'setCustomerSupplier',
-                'openvalue' => 'setOpenValue',
-                'openbasevalue' => 'setOpenBaseValue',
-                'repvalue' => 'setRepValue',
-                'matchlevel' => 'setMatchLevel',
-                'matchstatus' => 'setMatchStatus',
-            );
+                'basevalueopen'    => 'setBaseValueOpen',
+                'valueopen'        => 'setValueOpen',
+                'repvalue'         => 'setRepValue',
+                'matchlevel'       => 'setMatchLevel',
+                'matchstatus'      => 'setMatchStatus',
+            ];
 
-            foreach ($transactionElement->getElementsByTagName('line') as $lineDOM) {
+            foreach (
+                $transactionElement->getElementsByTagName('line') as $lineDOM
+            ) {
                 $temp_line = new TransactionLine();
 
                 $lineType = $lineDOM->getAttribute('type');

--- a/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
+++ b/src/Pronamic/Twinfield/Transaction/Mapper/TransactionMapper.php
@@ -20,7 +20,7 @@ class TransactionMapper
         $responseDOM = $response->getResponseDocument();
 
         // All tags for the transaction
-        $transactionTags = [
+        $transactionTags = array(
             'code'          => 'setCode',
             'currency'      => 'setCurrency',
             'date'          => 'setDate',
@@ -33,10 +33,10 @@ class TransactionMapper
             'freetext1'     => 'setFreetext1',
             'freetext2'     => 'setFreetext2',
             'freetext3'     => 'setFreetext3',
-        ];
+        );
 
         // Make new Transaction Object
-        $transactions = [];
+        $transactions = array();
 
         // Get the top level transaction element
         $transactionElements
@@ -78,7 +78,7 @@ class TransactionMapper
                 }
             }
 
-            $lineTags = [
+            $lineTags = array(
                 'dim1'             => 'setDim1',
                 'dim2'             => 'setDim2',
                 'value'            => 'setValue',
@@ -97,7 +97,7 @@ class TransactionMapper
                 'repvalue'         => 'setRepValue',
                 'matchlevel'       => 'setMatchLevel',
                 'matchstatus'      => 'setMatchStatus',
-            ];
+            );
 
             foreach (
                 $transactionElement->getElementsByTagName('line') as $lineDOM

--- a/src/Pronamic/Twinfield/Transaction/Transaction.php
+++ b/src/Pronamic/Twinfield/Transaction/Transaction.php
@@ -27,7 +27,10 @@ class Transaction extends BaseObject
     private $dueDate;
     private $invoiceNumber;
     private $number;
-    private $lines = array();
+    private $freetext1;
+    private $freetext2;
+    private $freetext3;
+    private $lines = [];
 
     /**
      * Add a TransactionLine to this Transaction.
@@ -199,6 +202,66 @@ class Transaction extends BaseObject
     public function setNumber($number)
     {
         $this->number = $number;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFreetext1()
+    {
+        return $this->freetext1;
+    }
+
+    /**
+     * @param mixed $freetext1
+     *
+     * @return Transaction
+     */
+    public function setFreetext1($freetext1)
+    {
+        $this->freetext1 = $freetext1;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFreetext2()
+    {
+        return $this->freetext2;
+    }
+
+    /**
+     * @param mixed $freetext2
+     *
+     * @return Transaction
+     */
+    public function setFreetext2($freetext2)
+    {
+        $this->freetext2 = $freetext2;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFreetext3()
+    {
+        return $this->freetext3;
+    }
+
+    /**
+     * @param mixed $freetext3
+     *
+     * @return Transaction
+     */
+    public function setFreetext3($freetext3)
+    {
+        $this->freetext3 = $freetext3;
 
         return $this;
     }

--- a/src/Pronamic/Twinfield/Transaction/Transaction.php
+++ b/src/Pronamic/Twinfield/Transaction/Transaction.php
@@ -30,7 +30,7 @@ class Transaction extends BaseObject
     private $freetext1;
     private $freetext2;
     private $freetext3;
-    private $lines = [];
+    private $lines = array();
 
     /**
      * Add a TransactionLine to this Transaction.

--- a/src/Pronamic/Twinfield/Transaction/TransactionLine.php
+++ b/src/Pronamic/Twinfield/Transaction/TransactionLine.php
@@ -30,8 +30,8 @@ class TransactionLine
     private $performanceDate;
     private $matchLevel;
     private $customerSupplier;
-    private $openValue;
-    private $openBaseValue;
+    private $valueOpen;
+    private $baseValueOpen;
     private $matchStatus;
 
     const PERFORMANCETYPE_SERVICES = 'services';
@@ -306,17 +306,6 @@ class TransactionLine
         return $this;
     }
 
-    public function getOpenBaseValue()
-    {
-        return $this->openBaseValue;
-    }
-
-    public function setOpenBaseValue($openBaseValue)
-    {
-        $this->openBaseValue = $openBaseValue;
-
-        return $this;
-    }
 
     public function getMatchStatus()
     {
@@ -326,6 +315,46 @@ class TransactionLine
     public function setMatchStatus($matchStatus)
     {
         $this->matchStatus = $matchStatus;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValueOpen()
+    {
+        return $this->valueOpen;
+    }
+
+    /**
+     * @param mixed $valueOpen
+     *
+     * @return TransactionLine
+     */
+    public function setValueOpen($valueOpen)
+    {
+        $this->valueOpen = $valueOpen;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBaseValueOpen()
+    {
+        return $this->baseValueOpen;
+    }
+
+    /**
+     * @param mixed $baseValueOpen
+     *
+     * @return TransactionLine
+     */
+    public function setBaseValueOpen($baseValueOpen)
+    {
+        $this->baseValueOpen = $baseValueOpen;
 
         return $this;
     }


### PR DESCRIPTION
The freetext1..3 was not supported and has been added in the definition

setOpenBaseValue (openbasevalue) needed to be renamed to setBaseValueOpen (basevalueopen) to match the API 

https://c3.twinfield.com/webservices/documentation/#/ApiReference/Transactions/BankTransactions

There might be some more cleanup needed between the API and fields defined

