### PR TITLE
Add dim1 to InvoiceLine and bugfix VatCode namespace

### DIFF
--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -132,7 +132,8 @@ class InvoicesDocument extends \DOMDocument
             'freetext1'       => 'getFreeText1',
             'freetext2'       => 'getFreeText2',
             'freetext3'       => 'getFreeText3',
-            'performancedate' => 'getPerformanceDate'
+            'performancedate' => 'getPerformanceDate',
+            'dim1'            => 'getDim1',
         );
 
         // Loop through all orders, and add those elements

--- a/src/Pronamic/Twinfield/Invoice/InvoiceLine.php
+++ b/src/Pronamic/Twinfield/Invoice/InvoiceLine.php
@@ -20,6 +20,7 @@ class InvoiceLine
     private $freeText2;
     private $freeText3;
     private $performanceDate;
+    private $dim1;
 
     public function __construct($quantity = null, $article = null, $freeText1 = null, $freeText2 = null)
     {
@@ -217,4 +218,17 @@ class InvoiceLine
         $this->performanceDate = $performanceDate;
         return $this;
     }
+
+    public function getDim1()
+    {
+        return $this->dim1;
+    }
+
+    public function setDim1($dim1)
+    {
+        $this->dim1 = $dim1;
+        return $this;
+    }
+
+
 }

--- a/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
+++ b/src/Pronamic/Twinfield/Invoice/Mapper/InvoiceMapper.php
@@ -91,7 +91,8 @@ class InvoiceMapper
             'freetext1'              => 'setFreeText1',
             'freetext2'              => 'setFreeText2',
             'freetext3'              => 'setFreeText3',
-            'performancedate'        => 'setPerformanceDate'
+            'performancedate'        => 'setPerformanceDate',
+            'dim1'                   => 'setDim1',
         );
 
         foreach ($responseDOM->getElementsByTagName('line') as $lineDOM) {

--- a/src/Pronamic/Twinfield/VatCode/VatCode.php
+++ b/src/Pronamic/Twinfield/VatCode/VatCode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace app\vendor\emilebons\twinfield\src\Pronamic\Twinfield\VatCode;
+namespace Pronamic\Twinfield\VatCode;
 
 /**
  * Class VatCode

--- a/src/Pronamic/Twinfield/VatCode/VatCodeFactory.php
+++ b/src/Pronamic/Twinfield/VatCode/VatCodeFactory.php
@@ -2,7 +2,6 @@
 
 namespace Pronamic\Twinfield\VatCode;
 
-use app\vendor\emilebons\twinfield\src\Pronamic\Twinfield\VatCode\VatCode;
 use Pronamic\Twinfield\Factory\FinderFactory;
 
 /**


### PR DESCRIPTION
This allows to specify and read 'dim1' on InvoiceLines which holds the balance account for that line. Also fixes a bug with wrong namespace on VatCode class.

Note: Tests on this will fail because of issue/pr #33 is not yet merged.