### PR TITLE
add getOffice to XML document

### DIFF
--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -88,6 +88,7 @@ class InvoicesDocument extends \DOMDocument
 
         // Elements and their associated methods for invoice
         $headerTags = array(
+            'office'               => 'getOffice',
             'invoicetype'          => 'getInvoiceType',
             'invoicenumber'        => 'getInvoiceNumber',
             'status'               => 'getStatus',


### PR DESCRIPTION
The office tag was missing from the salesinvoice header in the generated xml that will be sent to the Twinfield API